### PR TITLE
Fix fonts definitions in theme based on new rebass specs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## ooni-components 0.2.2 [2018-12-15]
+Changes:
+
+* Font definitions structure in Theme as per new rebass spec
+
+## ooni-components 0.2.1 [2018-10-16]
+Changes:
+
+* Publish only the necessary files to npm registry
+
 ## ooni-components 0.2.0 [2018-10-16]
 
 Changes:

--- a/components/theme/rebassTheme.js
+++ b/components/theme/rebassTheme.js
@@ -1,8 +1,10 @@
 import colors from './colors'
 
 export const rebassTheme = {
-  font: '"Fira Sans", sans-serif',
-  monospace: '"Source Code Pro", monospace',
+  fonts: {
+    sans: '"Fira Sans", sans-serif',
+    mono: '"Source Code Pro", monospace',
+  },
   maxWidth: 1024,
   space: [
     0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-components",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/index.js",
   "repository": "https://github.com/ooni/design-system.git",
   "author": "Arturo Filastò <arturo@filasto.net>",


### PR DESCRIPTION
The fonts were defaulting to `system-ui` because the rebass wasn't able to pick up the theme definitions. There don't seem to be any other theme structure changes. But it might be useful to take a look into leveraging unused theming features.