### PR TITLE
Use custom Container in Hero instead of rebass version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## ooni-components 0.2.5 [2019-03-22]
+Changes:
+
+* Use the custom `Container` in `Hero`
+
 ## ooni-components 0.2.4 [2019-03-11]
 Changes:
 

--- a/components/organisms/Hero.js
+++ b/components/organisms/Hero.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { space, fontSize, color, width } from '../util'
 
-import { Container } from 'rebass'
+import { Container } from '../components'
 
 const StyledHero = styled.div`
   ${space}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-components",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "dist/index.js",
   "repository": "https://github.com/ooni/design-system.git",
   "author": "Arturo Filastò <arturo@filasto.net>",

--- a/test/__snapshots__/Hero.test.js.snap
+++ b/test/__snapshots__/Hero.test.js.snap
@@ -10,7 +10,7 @@ exports[`Hero renders 1`] = `
 }
 
 .c1 {
-  max-width: 1024px;
+  max-width: 768px;
 }
 
 .c0 {
@@ -19,6 +19,18 @@ exports[`Hero renders 1`] = `
   background-color: #0588cb;
   color: #f8f9fa;
   text-align: center;
+}
+
+@media screen and (min-width:32em) {
+  .c1 {
+    max-width: 1024px;
+  }
+}
+
+@media screen and (min-width:48em) {
+  .c1 {
+    max-width: 1280px;
+  }
 }
 
 <Hero
@@ -31,31 +43,34 @@ exports[`Hero renders 1`] = `
       className="c0"
       fontSize={3}
     >
-      <ForwardRef
-        extend={[Function]}
-        maxWidth={1024}
+      <Styled(Box)
+        maxWidth={
+          Array [
+            768,
+            1024,
+            1280,
+          ]
+        }
         mx="auto"
         px={3}
       >
-        <ForwardRef
+        <Box
           className="c1"
-          extend={[Function]}
-          maxWidth={1024}
+          maxWidth={
+            Array [
+              768,
+              1024,
+              1280,
+            ]
+          }
           mx="auto"
           px={3}
         >
-          <Box
-            className="c1"
-            maxWidth={1024}
-            mx="auto"
-            px={3}
-          >
-            <div
-              className="c1 c2"
-            />
-          </Box>
-        </ForwardRef>
-      </ForwardRef>
+          <div
+            className="c1 c2"
+          />
+        </Box>
+      </Styled(Box)>
     </div>
   </Hero__StyledHero>
 </Hero>
@@ -71,7 +86,7 @@ exports[`Hero renders with children 1`] = `
 }
 
 .c1 {
-  max-width: 1024px;
+  max-width: 768px;
 }
 
 .c0 {
@@ -80,6 +95,18 @@ exports[`Hero renders with children 1`] = `
   background-color: #0588cb;
   color: #f8f9fa;
   text-align: center;
+}
+
+@media screen and (min-width:32em) {
+  .c1 {
+    max-width: 1024px;
+  }
+}
+
+@media screen and (min-width:48em) {
+  .c1 {
+    max-width: 1280px;
+  }
 }
 
 <Hero
@@ -92,35 +119,38 @@ exports[`Hero renders with children 1`] = `
       className="c0"
       fontSize={3}
     >
-      <ForwardRef
-        extend={[Function]}
-        maxWidth={1024}
+      <Styled(Box)
+        maxWidth={
+          Array [
+            768,
+            1024,
+            1280,
+          ]
+        }
         mx="auto"
         px={3}
       >
-        <ForwardRef
+        <Box
           className="c1"
-          extend={[Function]}
-          maxWidth={1024}
+          maxWidth={
+            Array [
+              768,
+              1024,
+              1280,
+            ]
+          }
           mx="auto"
           px={3}
         >
-          <Box
-            className="c1"
-            maxWidth={1024}
-            mx="auto"
-            px={3}
+          <div
+            className="c1 c2"
           >
             <div
-              className="c1 c2"
-            >
-              <div
-                key=".0"
-              />
-            </div>
-          </Box>
-        </ForwardRef>
-      </ForwardRef>
+              key=".0"
+            />
+          </div>
+        </Box>
+      </Styled(Box)>
     </div>
   </Hero__StyledHero>
 </Hero>


### PR DESCRIPTION
Trivial fix to use the recently added custom responsive-width Container. Currently, only the `Hero` component uses the `Container` from the [`rebass@2.x.x`](https://rebass-v2.now.sh/components/Container) package.