### PR TITLE
Add a OONI styled Link component

### DIFF
--- a/components/atoms/Link.js
+++ b/components/atoms/Link.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Link } from 'rebass'
+import styled from 'styled-components'
+
+const StyledLink = styled(Link)`
+  color: ${props => props.color || props.theme.colors.blue5};
+  text-decoration: none;
+
+  &:hover {
+    filter: brightness(125%);
+  }
+`
+
+export default StyledLink

--- a/components/atoms/index.js
+++ b/components/atoms/index.js
@@ -6,7 +6,7 @@ import IconButton from './IconButton'
 import { RadioGroup, RadioButton } from './Radio'
 import { Select } from './Select'
 import Container from './Container'
-
+import Link from './Link'
 import { TwitterShareButton, FacebookShareButton } from './ShareButton'
 
 const atoms = {
@@ -20,7 +20,8 @@ const atoms = {
   Select,
   TwitterShareButton,
   FacebookShareButton,
-  Container
+  Container,
+  Link
 }
 
 export default atoms

--- a/components/components.js
+++ b/components/components.js
@@ -17,6 +17,7 @@ export const Heading = atoms.Heading
 export const Text = atoms.Text
 export const Select = atoms.Select
 export const Container = atoms.Container
+export const Link = atoms.Link
 
 /* OONI produced molecules */
 export const InputWithIconButton = molecules.InputWithIconButton
@@ -59,7 +60,6 @@ import {
   Image,
   Label,
   Lead,
-  Link,
   Measure,
   Media,
   Message,

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -77,6 +77,17 @@ storiesOf('Components/Atoms/Select', module)
     </Select>
   ))
 
+storiesOf('Components/Atoms/Link', module)
+  .add('Default', () => (
+    <Link href='https://ooni.org'>OONI</Link>
+  ))
+  .add('Custom Color', () => (
+    <Link href='https://ooni.org' color='pink5'>OONI</Link>
+  ))
+  .add('Attributes', () => (
+    <Link href='https://ooni.org' target='_blank'>OONI (new tab)</Link>
+  ))
+
 storiesOf('Components/Molecules/Card', module)
   .add('Default', () => <Card />)
   .add('Many cards', () => <Flex flexWrap="wrap">

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -132,17 +132,17 @@ storiesOf('Components/Charts/PieChart', module)
 storiesOf('Components/Icons', module)
   .add('Default', () =>
     <Flex flexWrap='wrap'>
-      {Object.keys(icons).map(k => {
+      {Object.keys(icons).map((k, i) => {
         const Icon = icons[k]
         return (
-          <Box width={1/5} pb={3}>
+          <Box key={i} width={1/5} pb={3}>
             <Icon size={50} />
             <Text>{k}</Text>
           </Box>
         )
       })}
       <Box width={1/5} pb={3}>
-      <MdVolumeMute size={50} />
+        <MdVolumeMute size={50} />
       </Box>
     </Flex>
   )

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -16,7 +16,8 @@ import {
   Text,
   theme,
   Container,
-  Border
+  Border,
+  Link
 } from '../components'
 
 import { BarChart, PieChart, Modal } from '../components'

--- a/test/Link.test.js
+++ b/test/Link.test.js
@@ -1,0 +1,31 @@
+/* global describe, test, expect */
+import React from 'react'
+import { renderJSON, mountWithTheme } from './index'
+import { Link } from '../components'
+
+describe('Link', () => {
+  test('renders', () => {
+    const json = renderJSON(
+      <Link href='https://ooni.org'>OONI</Link>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with prop color', () => {
+    const linkColor = 'green8' // from theme
+    const json = renderJSON(
+      <Link color={linkColor}>OONI Green</Link>
+    )
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders a <a> tag with href', () => {
+    const wrapper = mountWithTheme(
+      <Link href='https://ooni.org'>OONI</Link>
+    )
+    expect(wrapper.find('a')).toHaveLength(1)
+    expect(wrapper.text()).toEqual('OONI')
+    expect(wrapper.getDOMNode()).toHaveProperty('href')
+    expect(wrapper.prop('href')).toEqual('https://ooni.org')
+  })
+})

--- a/test/__snapshots__/Link.test.js.snap
+++ b/test/__snapshots__/Link.test.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Link renders 1`] = `
+.c1 {
+  color: blue;
+}
+
+.c0 {
+  color: #0588cb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-filter: brightness(125%);
+  filter: brightness(125%);
+}
+
+<ForwardRef
+  href="https://ooni.org"
+>
+  <ForwardRef
+    className="c0"
+    color="blue"
+    href="https://ooni.org"
+    is="a"
+  >
+    <ForwardRef
+      className="c0 c1"
+      color="blue"
+      href="https://ooni.org"
+      is="a"
+    >
+      <a
+        className="c0 c1"
+        href="https://ooni.org"
+      >
+        OONI
+      </a>
+    </ForwardRef>
+  </ForwardRef>
+</ForwardRef>
+`;
+
+exports[`Link renders with prop color 1`] = `
+.c1 {
+  color: #2f9e44;
+}
+
+.c0 {
+  color: green8;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-filter: brightness(125%);
+  filter: brightness(125%);
+}
+
+<ForwardRef
+  color="green8"
+>
+  <ForwardRef
+    className="c0"
+    color="green8"
+    is="a"
+  >
+    <ForwardRef
+      className="c0 c1"
+      color="green8"
+      is="a"
+    >
+      <a
+        className="c0 c1"
+      >
+        OONI Green
+      </a>
+    </ForwardRef>
+  </ForwardRef>
+</ForwardRef>
+`;


### PR DESCRIPTION
Provides a `<Link>` component based on the one from `rebass` with the same name. Defaults the link color to OONI blue and removes the underline decoration.