### PR TITLE
v0.3.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,12 +1,23 @@
 # ChangeLog
 
-## ooni-components 0.2.10 [2019-12-16]
+## ooni-components 0.3.0 [2019-01-27]
+Adds:
+* Icon for `tor` test
+
+Changes:
+* **BREAKING** Supports styled-components@^4.0.0
+* Fixed `psiphon` test icon
+
+Removed:
+* Dropped misspelt color `fuschia`. Use `fuchsia`
+
+## ooni-components 0.2.11 [2019-12-16]
 Adds:
 * Add `<Link>` component styled with OONI theme
 * Add icon for circumvention test group
 
 Changes:
-* dependency upgrades by dependabot #
+* dependency upgrades by dependabot #65 #66 #69 #71
 
 Fixes:
 * Security fixes in dependency versions suggested by Github security advisories

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-components",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "repository": "https://github.com/ooni/design-system.git",
   "author": "Arturo Filastò <arturo@filasto.net>",


### PR DESCRIPTION
## ooni-components 0.3.0 [2019-01-27]
Adds:
* Icon for `tor` test

Changes:
* **BREAKING** Supports styled-components@^4.0.0
* Fixed `psiphon` test icon

Removed:
* Dropped misspelt color `fuschia`. Use `fuchsia`

