### PR TITLE
Updated Link default color to theme.colors.blue6 - Resubmit. 

### DIFF
--- a/components/atoms/Link.js
+++ b/components/atoms/Link.js
@@ -3,7 +3,7 @@ import { Link } from 'rebass'
 import styled from 'styled-components'
 
 const StyledLink = styled(Link)`
-  color: ${props => props.color || props.theme.colors.blue5};
+  color: ${props => props.color || props.theme.colors.blue6};
   text-decoration: none;
 
   &:hover {


### PR DESCRIPTION
Updated Link default color to theme.colors.blue6 instead of default color to theme.colors.blue5. Redoing for only the default change. 